### PR TITLE
Adds search time to search results page

### DIFF
--- a/app/facades/search_results_facade.rb
+++ b/app/facades/search_results_facade.rb
@@ -15,6 +15,10 @@ class SearchResultsFacade
     end
   end
 
+  def search_time
+    skyfield_data.body_data['data']['time']
+  end
+
   private
 
   def location

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -2,6 +2,7 @@
 
 <p class="search-results">
   My Location: <%= @facade.user_estimated_location %>
+  <p id="search-time"> Search time (UTC): <%= @facade.search_time %></p>
 
   <% @facade.body_results.each do |body| %>
     <section class="body">

--- a/spec/features/users/user_can_see_search_results_spec.rb
+++ b/spec/features/users/user_can_see_search_results_spec.rb
@@ -32,6 +32,9 @@ describe 'User can see search results' do
 
     expect(current_path).to eq(search_index_path)
     expect(page).to have_content("My Location: 1331 17th Street, Denver, Colorado 80202, United States")
+
+    expect(page).to have_css("#search-time")
+
     expect(page).to have_css(".body", count: 2)
 
     within first ".body" do


### PR DESCRIPTION
## Pull Request Review Template

- [x] Wrote Tests
- [] Implemented
- [] Reviewed

### Necessary checkmarks:
- x] All Tests are Passing
- [] The code will run locally

### Type of change
- [x] New feature
- [] Bug Fix

### Implements/Fixes:
Implements first part of #56 
Adds search time to the search results page. 

### Description of Changes:
Grabbed this search time from the Skyfield Service data since we already built it to return the UTC time. I only tested for the page having the CSS.  It is using the fixture data and the time.now changes each time.

Something we should consider is how to format this time for the client's browser's time zone. I will created this as an ICEBOX issue for now, see card #72 

closes#

### Check the correct boxes
- [x] This broke nothing
- [] This broke some stuff
- [] This broke everything

### Testing Changes
- COVERAGE SCORE:
- [x] New Tests have been added
- [] No Tests have been changed
- [] Some Tests have been changed
- [] All of the Tests have been changed (Please describe what in the world happened)

### Checklist:
- [x] My code has no unused/commented out code
- [] I have reviewed my code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have fully tested my code
