### PR TITLE
Adds text alerts for 15 mins prior to next ISS rise time

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ gem 'pg'
 gem 'local_time'
 gem 'sidekiq'
 gem 'sinatra'
+gem 'twilio-ruby'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -318,6 +318,10 @@ GEM
     turbolinks (5.2.0)
       turbolinks-source (~> 5.2)
     turbolinks-source (5.2.0)
+    twilio-ruby (5.23.1)
+      faraday (~> 0.9)
+      jwt (>= 1.5, <= 2.5)
+      nokogiri (>= 1.6, < 2.0)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     uber (0.1.0)
@@ -378,6 +382,7 @@ DEPENDENCIES
   spring
   spring-watcher-listen (~> 2.0.0)
   turbolinks (~> 5)
+  twilio-ruby
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)

--- a/app/controllers/iss_alerts_controller.rb
+++ b/app/controllers/iss_alerts_controller.rb
@@ -1,0 +1,14 @@
+class IssAlertsController < ApplicationController
+  def create
+    phone_number = '+1' + params['phone'].delete('-')
+    scheduled_time = Time.parse(params['scheduled_time'])
+
+    rise_time = scheduled_time + (15 * 60)
+    message = "The Int'l Space Station will be rising near you at #{rise_time}. Space In Your Face!"
+
+    alert = TextAlert.perform_at(scheduled_time, phone_number, message)
+
+    flash[:message] = "Text message successfully scheduled for #{params[:phone]} for next ISS rise time at #{scheduled_time}."
+    redirect_to root_path
+  end
+end

--- a/app/jobs/text_alert.rb
+++ b/app/jobs/text_alert.rb
@@ -1,0 +1,18 @@
+class TextAlert
+  include Sidekiq::Worker
+
+  def perform(phone_number, message)
+    send(phone_number, message)
+  end
+
+  def send(phone_number, message)
+    client = Twilio::REST::Client.new(ENV['TWILIO_ACCOUNT_SID'], ENV['TWILIO_AUTH_TOKEN'])
+    from = ENV['TWILIO_PHONE_NUMBER']
+
+    client.api.account.messages.create(
+    from: from,
+    to: phone_number,
+    body: message
+    )
+  end
+end

--- a/app/views/iss_search/index.html.erb
+++ b/app/views/iss_search/index.html.erb
@@ -7,3 +7,18 @@
   <p>Next Rise Time: <%= local_time(facade.next_rise_time) %></p>
   <p>Duration: <%= facade.duration %> minutes </p>
 </div>
+
+<%= form_tag('/iss_alerts', method: :get) do %>
+  <label for="phone">Enter your phone number to schedule a text message alert 15 mins prior to next rise time (<%= local_time(facade.next_rise_time - (15 * 60)) %>):</label>
+
+  <input type="tel" id="phone" name="phone"
+    pattern="[0-9]{3}-[0-9]{3}-[0-9]{4}"
+    placeholder="Format: 123-456-7890"
+    title="Format: 123-456-7890"
+    required>
+
+  <%= hidden_field_tag :scheduled_time, (facade.next_rise_time - (15 * 60)) %>
+  <p id='submit'>
+    <%= submit_tag("Schedule text message") %>
+  </p>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,8 @@ Rails.application.routes.draw do
   get 'auth/google_oauth2/callback', to: 'sessions#create'
 
   resources :iss_search, only: [:index, :new]
-  
+  get '/iss_alerts', to: 'iss_alerts#create'
+
   require 'sidekiq/web'
   mount Sidekiq::Web => '/sidekiq'
 end


### PR DESCRIPTION
## Pull Request Review Template

- [] Wrote Tests
- [x] Implemented
- [x] Reviewed

### Necessary checkmarks:
- [] All Tests are Passing
- [x] The code will run locally

### Type of change
- [x] New feature
- [] Bug Fix

### Implements/Fixes:
Implements text alert notification for 15 minutes prior to next ISS rise time. 

### Description of Changes:
Users can now enter their phone number on the `iss_search/index` page and schedule a text message.

This is working locally but will require configuration for Heroku that I will debug tomorrow.  There are 3 new ENV variables for Twilio I will share with the team tomorrow.

Also, need help styling, it's pretty ugly:
<img width="1105" alt="Screen Shot 2019-05-30 at 12 57 35 AM" src="https://user-images.githubusercontent.com/36040194/58614589-0699b800-8276-11e9-8841-00ed75339a46.png">


closes#

### Check the correct boxes
- [x] This broke nothing
- [] This broke some stuff
- [] This broke everything

### Testing Changes
- COVERAGE SCORE:
- [] New Tests have been added
- [x] No Tests have been changed
- [] Some Tests have been changed
- [] All of the Tests have been changed (Please describe what in the world happened)

### Checklist:
- [x] My code has no unused/commented out code
- [x] I have reviewed my code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have fully tested my code
