### PR TITLE
Removes unnecessary oauth callback route in routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,6 @@ Rails.application.routes.draw do
   post '/login', to: 'sessions#create'
   delete '/logout', to: 'sessions#destroy'
 
-  get '/o/oauth2/auth', to: 'sessions#create'
   get 'auth/google_oauth2/callback', to: 'sessions#create'
 
   resources :iss_search, only: [:index, :new]


### PR DESCRIPTION
## Pull Request Review Template

- [] Wrote Tests
- [x] Implemented
- [x] Reviewed

### Necessary checkmarks:
- [x] All Tests are Passing
- [x] The code will run locally

### Type of change
- [] New feature
- [x] Bug Fix

### Implements/Fixes:
Previously unable to use OAuth when using `http`

### Description of Changes:
Updated OAuth callback information in google settings to account for both `http` and `https`.
In code base, removed unnecessary `get '/o/oauth2/auth', to: 'sessions#create'` from routes. All local, and other tests are passing.

### Check the correct boxes
- [x] This broke nothing
- [] This broke some stuff
- [] This broke everything

### Testing Changes
- COVERAGE SCORE:
- [] New Tests have been added
- [x] No Tests have been changed
- [] Some Tests have been changed
- [] All of the Tests have been changed (Please describe what in the world happened)

### Checklist:
- [] My code has no unused/commented out code
- [x] I have reviewed my code
- [] I have commented my code, particularly in hard-to-understand areas
- [x] I have fully tested my code
