### PR TITLE
Fixes register here container - text alert confirmation in green

### DIFF
--- a/app/assets/stylesheets/welcome.scss
+++ b/app/assets/stylesheets/welcome.scss
@@ -42,15 +42,11 @@
   width: 75%;
   color: white;
   background-color: rgba(34,37,43,0.75);
-
+  text-align: center;
   font-size: 25px;
   padding-top: 25px;
   padding-bottom: 25px;
   padding: 20px;
-  border-style: solid;
-  border-color: navy;
-  border-width: 5px;
-  border-spacing: 10px;
 }
 
 .welcome-content {

--- a/app/controllers/iss_alerts_controller.rb
+++ b/app/controllers/iss_alerts_controller.rb
@@ -11,7 +11,7 @@ class IssAlertsController < ApplicationController
 
     alert = TextAlert.perform_at(scheduled_time, phone_number, message)
 
-    flash[:message] = "#{formatted_phone_number} - Text message successfully scheduled for next ISS rise time: #{formatted_rise_time}."
+    flash[:success] = "#{formatted_phone_number} - Text message successfully scheduled for next ISS rise time: #{formatted_rise_time}."
     redirect_to new_search_path
   end
 end


### PR DESCRIPTION
Co-authored-by: Deonte Cooper <45864171+djc00p@users.noreply.github.com>
Co-authored-by: Jeremy Bennett  <25406708+JaxJafinPapau@users.noreply.github.com>
Co-authored-by: Matt Levy <36040194+milevy1@users.noreply.github.com>
Co-authored-by: Matt Weiss <45211960+Matt-Weiss@users.noreply.github.com>

## Pull Request Review Template

- [] Wrote Tests
- [x] Implemented
- [x] Reviewed

### Necessary checkmarks:
- [x] All Tests are Passing
- [x] The code will run locally

### Type of change
- [] New feature
- [x] Bug Fix

### Implements/Fixes:
- 'Click Here' container had a border on it - this removes that border and centers text.

### Description of Changes:
- Text Alert now shows up in green background (Flash Message)

closes#

### Check the correct boxes
- [x] This broke nothing
- [] This broke some stuff
- [] This broke everything

### Testing Changes
- COVERAGE SCORE:
- [] New Tests have been added
- [] No Tests have been changed
- [] Some Tests have been changed
- [] All of the Tests have been changed (Please describe what in the world happened)

### Checklist:
- [] My code has no unused/commented out code
- [] I have reviewed my code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have fully tested my code
