### PR TITLE
Text timezones

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ gem 'pg'
 gem 'local_time'
 gem 'sidekiq'
 gem 'sinatra'
+gem 'timezone', '~> 1.0'
 gem 'twilio-ruby'
 gem 'redis'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -315,6 +315,7 @@ GEM
     thor (0.20.3)
     thread_safe (0.3.6)
     tilt (2.0.9)
+    timezone (1.3.4)
     turbolinks (5.2.0)
       turbolinks-source (~> 5.2)
     turbolinks-source (5.2.0)
@@ -382,6 +383,7 @@ DEPENDENCIES
   sinatra
   spring
   spring-watcher-listen (~> 2.0.0)
+  timezone (~> 1.0)
   turbolinks (~> 5)
   twilio-ruby
   tzinfo-data

--- a/app/controllers/iss_alerts_controller.rb
+++ b/app/controllers/iss_alerts_controller.rb
@@ -2,16 +2,27 @@ class IssAlertsController < ApplicationController
   def create
     phone_number = '+1' + params['phone']
     formatted_phone_number = params['phone'][0..2] + '-' + params['phone'][3..5] + '-' + params['phone'][6..9]
-    scheduled_time = Time.parse(params['scheduled_time'])
+    location = formatted_location(params['location'])
+    time_zone = Timezone.lookup(location[1], location[0]).name
+    rise_time = Time.parse(params['rise_time'])
+    scheduled_time = rise_time - 15.minutes
+    formatted_rise_time = rise_time.in_time_zone(time_zone).strftime("%A, %b %e at%l:%M%p %Z")
 
-    rise_time = scheduled_time + (15 * 60)
-    formatted_rise_time = rise_time.strftime("%a %b%e %l:%M%p %Z")
-
-    message = "The International Space Station will be rising near you soon: #{formatted_rise_time}. SpaceInYourFace.herokuapp.com"
-
-    alert = TextAlert.perform_at(scheduled_time, phone_number, message)
+    alert = TextAlert.perform_at(scheduled_time, phone_number, message(formatted_rise_time))
 
     flash[:success] = "#{formatted_phone_number} - Text message successfully scheduled for next ISS rise time: #{formatted_rise_time}."
     redirect_to new_search_path
   end
+
+  private
+
+    def message(formatted_rise_time)
+      "The International Space Station will be rising near you soon: #{formatted_rise_time}. SpaceInYourFace.herokuapp.com"
+    end
+
+    def formatted_location(strf_location)
+      strf_location.split.map do |coord|
+        coord.to_f
+      end
+    end
 end

--- a/app/facades/iss_search_result_facade.rb
+++ b/app/facades/iss_search_result_facade.rb
@@ -3,6 +3,10 @@ class IssSearchResultFacade
     @raw_location = iss_search_params['location']
   end
 
+  def mapbox_long_lat
+    mapbox_best_guess["center"]
+  end
+  
   def user_estimated_location
     mapbox_best_guess["place_name"]
   end
@@ -12,7 +16,7 @@ class IssSearchResultFacade
   end
 
   def next_rise_time
-    Time.parse(iss_data['start']).localtime
+    Time.parse(iss_data['start'])
   end
 
   def duration
@@ -38,7 +42,4 @@ class IssSearchResultFacade
       location.returned_locations["features"].first
     end
 
-    def mapbox_long_lat
-      mapbox_best_guess["center"]
-    end
 end

--- a/app/views/iss_search/index.html.erb
+++ b/app/views/iss_search/index.html.erb
@@ -20,7 +20,7 @@
         title="Format: 1234567890"
         required>
 
-        <%= hidden_field_tag :scheduled_time, (local_time(facade.next_rise_time) - (15 * 60)) %>
+        <%= hidden_field_tag :rise_time, local_time(facade.next_rise_time) %>
         <p id='submit'>
           <%= submit_tag("Schedule text message") %>
         </p>

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -55,7 +55,8 @@
         title="Format: 1234567890"
         required>
 
-      <%= hidden_field_tag :scheduled_time, (@facade.next_rise_time - (15 * 60)) %>
+      <%= hidden_field_tag :rise_time, @facade.next_rise_time %>
+      <%= hidden_field_tag :location, @facade.mapbox_long_lat %>
       <p id='submit'>
         <%= submit_tag("Schedule text message") %>
       </p>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -58,4 +58,7 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+  Timezone::Lookup.config(:geonames) do |c|
+     c.username = 'spaceinyourface'
+  end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -89,7 +89,9 @@ Rails.application.configure do
     logger.formatter = config.log_formatter
     config.logger    = ActiveSupport::TaggedLogging.new(logger)
   end
-
+  Timezone::Lookup.config(:geonames) do |c|
+     c.username = 'spaceinyourface'
+  end
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 end


### PR DESCRIPTION
## Pull Request Review Template

- [] Wrote Tests
- [x] Implemented
- [] Reviewed

### Necessary checkmarks:
- [x] All Tests are Passing
- [x] The code will run locally

### Type of change
- [] New feature
- [x] Bug Fix

### Implements/Fixes: Second attempt at debugging the UTC time zone in our text messages.

### Description of Changes: Incorporates a new gem, time_zones, and api call to Geonames. Updates the params sent to the iss_alerts_controller to now include location and makes a call to the aforementioned gem/api combo to properly give the time zone that the user searched for and formats times and text messages accoringly.

### Check the correct boxes
- [x] This broke nothing
- [] This broke some stuff
- [] This broke everything

### Testing Changes
- COVERAGE SCORE:
- [] New Tests have been added
- [x] No Tests have been changed
- [] Some Tests have been changed
- [] All of the Tests have been changed (Please describe what in the world happened)

### Checklist:
- [x] My code has no unused/commented out code
- [x] I have reviewed my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have fully tested my code - LOCALLY, we need to test this in production.
